### PR TITLE
feat(content): preserve Notion image captions and render as figcaption

### DIFF
--- a/app/components/mdx-components.tsx
+++ b/app/components/mdx-components.tsx
@@ -164,29 +164,41 @@ export const getMdxComponents = (ctx: MdxContext) => {
     a: Anchor,
     img: async ({ src, alt }: React.ImgHTMLAttributes<HTMLImageElement>) => {
       if (!src || typeof src !== "string") return null;
+      const caption = (alt ?? "").trim();
       // ExportedImage only handles locally optimized images; fall back to
       // a plain <img> for external URLs.
+      let media: React.ReactNode;
       if (src.startsWith("http://") || src.startsWith("https://")) {
-        return (
+        media = (
           // eslint-disable-next-line @next/next/no-img-element
           <img
             src={src}
-            alt={alt || ""}
+            alt={caption}
             style={{ width: "100%", height: "auto" }}
           />
         );
+      } else {
+        const meta = await getImageMeta();
+        const dimensions = meta[src] ?? { width: 1200, height: 800 };
+        media = (
+          <ExportedImage
+            src={src}
+            alt={caption}
+            width={dimensions.width}
+            height={dimensions.height}
+            style={{ width: "100%", height: "auto" }}
+            sizes="(max-width: 768px) 100vw, 720px"
+          />
+        );
       }
-      const meta = await getImageMeta();
-      const dimensions = meta[src] ?? { width: 1200, height: 800 };
+      if (!caption) return media;
       return (
-        <ExportedImage
-          src={src}
-          alt={alt || ""}
-          width={dimensions.width}
-          height={dimensions.height}
-          style={{ width: "100%", height: "auto" }}
-          sizes="(max-width: 768px) 100vw, 720px"
-        />
+        <figure className="my-6">
+          {media}
+          <figcaption className="text-sm text-gray-500 text-center mt-2 leading-snug">
+            {caption}
+          </figcaption>
+        </figure>
       );
     },
     Note: FloatingNote,

--- a/scripts/sync-notion.ts
+++ b/scripts/sync-notion.ts
@@ -33,7 +33,12 @@ const n2m = new NotionToMarkdown({ notionClient: notion });
 // Track images to download: blockId -> url
 const imageMap = new Map<string, string>();
 
-// Custom image transformer: use placeholder, collect image info
+// Escape characters that would break the markdown image-alt syntax.
+function escapeAlt(text: string): string {
+  return text.replace(/\\/g, "\\\\").replace(/\]/g, "\\]").replace(/\s+/g, " ").trim();
+}
+
+// Custom image transformer: use placeholder, collect image info, preserve caption
 n2m.setCustomTransformer("image", (node) => {
   if ("type" in node && node.type === "image") {
     const url =
@@ -41,7 +46,11 @@ n2m.setCustomTransformer("image", (node) => {
         ? node.image.file.url
         : node.image.external.url;
     imageMap.set(node.id, url);
-    return `![](/__NOTION_IMAGE__${node.id}__)`;
+    const caption = (node.image.caption ?? [])
+      .map((rt: { plain_text?: string }) => rt.plain_text ?? "")
+      .join("");
+    const alt = escapeAlt(caption);
+    return `![${alt}](/__NOTION_IMAGE__${node.id}__)`;
   }
   return "";
 });
@@ -199,11 +208,11 @@ function replaceImagePlaceholders(
   downloadedImages: Map<string, string>
 ): string {
   return md.replace(
-    /!\[\]\(\/__NOTION_IMAGE__([a-f0-9-]+)__\)/g,
-    (match, blockId) => {
+    /!\[((?:\\\]|[^\]])*)\]\(\/__NOTION_IMAGE__([a-f0-9-]+)__\)/g,
+    (match, alt, blockId) => {
       const filename = downloadedImages.get(blockId);
       if (filename) {
-        return `![](/notion-images/${filename})`;
+        return `![${alt}](/notion-images/${filename})`;
       }
       console.warn(`  [warn] No downloaded image for block ${blockId}`);
       return match;


### PR DESCRIPTION
## Summary

The Notion sync transformer was emitting `![](path)` with empty alt, dropping any caption text authored on the Notion image block. Two changes:

1. **`scripts/sync-notion.ts`** — extract `node.image.caption` plain text into the markdown alt: `![caption](placeholder)`. Escape `\\` and `]` so captions with special chars survive the markdown round-trip. `replaceImagePlaceholders` regex now preserves the alt when swapping the placeholder for the final filename.
2. **`app/components/mdx-components.tsx`** — when alt is non-empty, wrap the `<ExportedImage>` (or fallback `<img>`) in a `<figure>` and render a `<figcaption className="text-sm text-gray-500 text-center mt-2 leading-snug">` below. Images without captions render exactly as before (no `<figure>` wrapper, no caption row).

After merge, re-run the `sync-notion` workflow to repopulate captions for existing Publish=true posts whose Notion image blocks have captions.

For the new Slock post specifically: the 4 image blocks in Notion all have captions set (verified via API). On next sync those will surface as `<figcaption>` below each image.

## Test plan

- [x] Local `pnpm build` — 23/23 static pages clean, no TS errors
- [ ] Cloudflare Pages preview build green
- [ ] After merge: re-trigger `sync-notion.yml`, then verify <https://pengx17.pages.dev/posts/slock-multi-agent-observations> shows captions under each image

🤖 Generated with [Claude Code](https://claude.com/claude-code)