### PR TITLE
feat(mdx): render floating notes in page rail

### DIFF
--- a/app/(non-home)/post-renderer.tsx
+++ b/app/(non-home)/post-renderer.tsx
@@ -5,6 +5,7 @@ import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 
 import { use } from "react";
+import { FloatingNotesProvider } from "../components/floating-note";
 import { getMdxComponents } from "../components/mdx-components";
 import { DateString } from "../date";
 import { getPageMD, type PostProperties } from "../lib/content-data";
@@ -24,22 +25,24 @@ export function PostRenderer({ id, name, date }: Partial<PostProperties>) {
           <DateString dateString={date} />
         </div>
       )}
-      {/* @ts-ignore */}
-      <MDXRemote
-        source={md}
-        components={getMdxComponents({
-          notes,
-        })}
-        options={{
-          mdxOptions: {
-            remarkPlugins: [remarkGfm],
-            rehypePlugins: [
-              rehypeSlug,
-              [rehypeShiki, { themes: { light: "github-light" } }],
-            ],
-          },
-        }}
-      />
+      <FloatingNotesProvider>
+        {/* @ts-ignore */}
+        <MDXRemote
+          source={md}
+          components={getMdxComponents({
+            notes,
+          })}
+          options={{
+            mdxOptions: {
+              remarkPlugins: [remarkGfm],
+              rehypePlugins: [
+                rehypeSlug,
+                [rehypeShiki, { themes: { light: "github-light" } }],
+              ],
+            },
+          }}
+        />
+      </FloatingNotesProvider>
     </>
   );
 }

--- a/app/components/floating-note.tsx
+++ b/app/components/floating-note.tsx
@@ -1,8 +1,296 @@
 "use client";
 
 import React from "react";
-import ReactDom from "react-dom";
-import { useHoverDirty, useWindowSize } from "react-use";
+
+type NoteItem = {
+  id: string;
+  label: React.ReactNode;
+  content: React.ReactNode;
+  anchor: HTMLElement | null;
+};
+
+type NotePosition = {
+  id: string;
+  top: number;
+  marker: boolean;
+  targetTop: number;
+};
+
+type FloatingNoteContextValue = {
+  activeId: string | null;
+  register: (note: NoteItem) => void;
+  unregister: (id: string) => void;
+  setAnchor: (id: string, anchor: HTMLElement | null) => void;
+  setActiveId: (id: string | null) => void;
+};
+
+const FloatingNoteContext =
+  React.createContext<FloatingNoteContextValue | null>(null);
+
+const NOTE_RAIL_TOP = 72;
+const NOTE_RAIL_BOTTOM = 28;
+const NOTE_MIN_GAP = 12;
+
+function cx(...args: (string | false | null | undefined)[]) {
+  return args.filter(Boolean).join(" ");
+}
+
+function estimateHeight(note: NoteItem, active: boolean) {
+  const contentText =
+    typeof note.content === "string"
+      ? note.content
+      : typeof note.label === "string"
+        ? note.label
+        : "";
+  const estimated = Math.ceil(contentText.length / 36) * 20 + 36;
+  return Math.max(44, Math.min(active ? 260 : 128, estimated || 92));
+}
+
+function placeNotes({
+  notes,
+  activeId,
+  heights,
+}: {
+  notes: NoteItem[];
+  activeId: string | null;
+  heights: Map<string, number>;
+}) {
+  if (typeof window === "undefined" || window.innerWidth < 768) {
+    return [];
+  }
+
+  const centerY = window.innerHeight * 0.46;
+  const candidates = notes
+    .map((note) => {
+      if (!note.anchor) return null;
+      const rect = note.anchor.getBoundingClientRect();
+      if (rect.bottom < -160 || rect.top > window.innerHeight + 160) {
+        return null;
+      }
+      const measured = heights.get(note.id);
+      const height = measured || estimateHeight(note, note.id === activeId);
+      const targetTop = rect.top + rect.height / 2 - height / 2;
+      return {
+        id: note.id,
+        height,
+        targetTop,
+        viewportDistance: Math.abs(rect.top + rect.height / 2 - centerY),
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a!.targetTop - b!.targetTop) as {
+    id: string;
+    height: number;
+    targetTop: number;
+    viewportDistance: number;
+  }[];
+
+  if (!candidates.length) return [];
+
+  const bottomLimit = Math.max(
+    NOTE_RAIL_TOP + 120,
+    window.innerHeight - NOTE_RAIL_BOTTOM,
+  );
+
+  const laidOut: (typeof candidates[number] & { top: number })[] = [];
+  for (const item of candidates) {
+    const previous = laidOut[laidOut.length - 1];
+    laidOut.push({
+      ...item,
+      top: Math.max(
+        NOTE_RAIL_TOP,
+        item.targetTop,
+        previous ? previous.top + previous.height + NOTE_MIN_GAP : NOTE_RAIL_TOP,
+      ),
+    });
+  }
+
+  for (let index = laidOut.length - 1; index >= 0; index -= 1) {
+    const item = laidOut[index];
+    const maxTop =
+      index === laidOut.length - 1
+        ? bottomLimit - item.height
+        : laidOut[index + 1].top - NOTE_MIN_GAP - item.height;
+    item.top = Math.min(item.top, maxTop);
+  }
+
+  return laidOut.map((item) => ({
+    id: item.id,
+    top: Math.max(NOTE_RAIL_TOP, item.top),
+    targetTop: item.targetTop,
+    marker:
+      item.id !== activeId &&
+      (item.top < NOTE_RAIL_TOP ||
+        item.top + item.height > bottomLimit ||
+        item.viewportDistance > window.innerHeight * 0.62),
+  }));
+}
+
+function FloatingNoteRail({
+  notes,
+  activeId,
+  setActiveId,
+}: {
+  notes: NoteItem[];
+  activeId: string | null;
+  setActiveId: (id: string | null) => void;
+}) {
+  const noteRefs = React.useRef(new Map<string, HTMLElement>());
+  const [positions, setPositions] = React.useState<NotePosition[]>([]);
+  const [viewportHeight, setViewportHeight] = React.useState(0);
+
+  const updatePositions = React.useCallback(() => {
+    setViewportHeight(window.innerHeight);
+    const heights = new Map<string, number>();
+    noteRefs.current.forEach((el, id) => {
+      heights.set(id, el.offsetHeight);
+    });
+    setPositions(placeNotes({ notes, activeId, heights }));
+  }, [activeId, notes]);
+
+  React.useEffect(() => {
+    updatePositions();
+    const onChange = () => requestAnimationFrame(updatePositions);
+    window.addEventListener("scroll", onChange, { passive: true });
+    window.addEventListener("resize", onChange);
+    const observer = new ResizeObserver(onChange);
+    observer.observe(document.body);
+    return () => {
+      window.removeEventListener("scroll", onChange);
+      window.removeEventListener("resize", onChange);
+      observer.disconnect();
+    };
+  }, [updatePositions]);
+
+  React.useEffect(() => {
+    updatePositions();
+  }, [activeId, updatePositions]);
+
+  if (!notes.length) return null;
+
+  const positionById = new Map(positions.map((pos) => [pos.id, pos]));
+  const activePosition = positions.find((pos) => pos.id === activeId);
+  const nearestId =
+    activeId ||
+    positions
+      .slice()
+      .sort(
+        (a, b) =>
+          Math.abs(a.targetTop - viewportHeight * 0.46) -
+          Math.abs(b.targetTop - viewportHeight * 0.46),
+      )[0]?.id ||
+    null;
+
+  return (
+    <div
+      aria-hidden={positions.length === 0}
+      className="pointer-events-none fixed inset-y-0 right-6 z-20 hidden w-44 md:block lg:right-10 lg:w-56 xl:right-[max(3rem,calc((100vw-72rem)/2+2rem))] xl:w-64"
+    >
+      <div className="relative h-full">
+        {activePosition && (
+          <div
+            className="absolute right-full mr-2 h-px w-8 bg-gray-300 transition-transform"
+            style={{ transform: `translateY(${activePosition.top + 18}px)` }}
+          />
+        )}
+        {notes.map((note) => {
+          const position = positionById.get(note.id);
+          if (!position) return null;
+          const focused = note.id === activeId || note.id === nearestId;
+          if (position.marker) {
+            return (
+              <button
+                key={note.id}
+                type="button"
+                aria-label="Show note"
+                className="pointer-events-auto absolute right-0 h-2 w-10 rounded-full bg-gray-300 transition hover:bg-gray-700"
+                style={{ transform: `translateY(${position.top + 12}px)` }}
+                onMouseEnter={() => setActiveId(note.id)}
+                onFocus={() => setActiveId(note.id)}
+                onClick={() => setActiveId(note.id)}
+              />
+            );
+          }
+          return (
+            <aside
+              key={note.id}
+              ref={(el) => {
+                if (el) noteRefs.current.set(note.id, el);
+                else noteRefs.current.delete(note.id);
+              }}
+              className={cx(
+                "pointer-events-auto absolute right-0 rounded-sm border bg-white/92 px-3 py-2 text-xs leading-relaxed text-gray-800 shadow-sm backdrop-blur transition-all duration-200",
+                focused
+                  ? "max-h-64 overflow-auto border-gray-800 opacity-100"
+                  : "max-h-28 overflow-hidden border-gray-200 opacity-45 hover:opacity-90",
+              )}
+              style={{ transform: `translateY(${position.top}px)` }}
+              onMouseEnter={() => setActiveId(note.id)}
+              onMouseLeave={() => setActiveId(null)}
+              onFocus={() => setActiveId(note.id)}
+            >
+              {note.content}
+            </aside>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function FloatingNotesProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [notesById, setNotesById] = React.useState<Record<string, NoteItem>>(
+    {},
+  );
+  const [activeId, setActiveId] = React.useState<string | null>(null);
+
+  const register = React.useCallback((note: NoteItem) => {
+    setNotesById((current) => ({ ...current, [note.id]: note }));
+  }, []);
+
+  const unregister = React.useCallback((id: string) => {
+    setNotesById((current) => {
+      const next = { ...current };
+      delete next[id];
+      return next;
+    });
+  }, []);
+
+  const setAnchor = React.useCallback(
+    (id: string, anchor: HTMLElement | null) => {
+      setNotesById((current) => {
+        const existing = current[id];
+        if (!existing || existing.anchor === anchor) return current;
+        return { ...current, [id]: { ...existing, anchor } };
+      });
+    },
+    [],
+  );
+
+  const value = React.useMemo(
+    () => ({ activeId, register, unregister, setAnchor, setActiveId }),
+    [activeId, register, setAnchor, unregister],
+  );
+  const notes = React.useMemo(() => Object.values(notesById), [notesById]);
+  const hasNotes = notes.length > 0;
+
+  return (
+    <FloatingNoteContext.Provider value={value}>
+      <div className={hasNotes ? "md:pr-48 lg:pr-64 xl:pr-72" : undefined}>
+        {children}
+      </div>
+      <FloatingNoteRail
+        notes={notes}
+        activeId={activeId}
+        setActiveId={setActiveId}
+      />
+    </FloatingNoteContext.Provider>
+  );
+}
 
 export function FloatingNote({
   label,
@@ -12,69 +300,48 @@ export function FloatingNote({
   label: React.ReactNode;
   children: React.ReactNode;
 }) {
-  const triggerRef = React.useRef<HTMLElement | null>(null);
-  const [anchor, setAnchor] = React.useState<HTMLElement>();
-  const asideRef = React.useRef<HTMLElement | null>(null);
-  const triggerHovering = useHoverDirty(triggerRef as React.RefObject<Element>);
-  const asideHovering = useHoverDirty(asideRef as React.RefObject<Element>, !!anchor);
+  const id = React.useId();
+  const triggerRef = React.useRef<HTMLSpanElement | null>(null);
+  const context = React.useContext(FloatingNoteContext);
 
   React.useEffect(() => {
-    if (triggerRef.current && !anchor) {
-      setTimeout(() => {
-        let el = triggerRef.current
-          ?.closest("section")
-          ?.querySelector<HTMLElement>("[data-aside-container]");
-        setAnchor(el ?? undefined);
-      }, 100);
-    }
-  }, [triggerRef, anchor]);
+    if (!context) return;
+    context.register({
+      id,
+      label,
+      content: children,
+      anchor: triggerRef.current,
+    });
+    context.setAnchor(id, triggerRef.current);
+    return () => context.unregister(id);
+  }, [children, context, id, label]);
 
-  // This will trigger re-render when window size changed.
-  useWindowSize();
+  React.useEffect(() => {
+    if (!context) return;
+    context.setAnchor(id, triggerRef.current);
+  }, [context, id]);
 
-  const focused = triggerHovering || asideHovering;
-  const asideEl =
-    anchor &&
-    ReactDom.createPortal(
-      <aside
-        ref={asideRef}
-        style={{
-          borderColor: triggerHovering ? "rgba(31, 41, 55)" : undefined,
-          lineHeight: 1.6,
-          // Dim non-focused notes so consecutive floating notes don't fight
-          // for visual attention when their sticky containers visually
-          // collide in the right margin; the hovered one wins.
-          opacity: focused ? 1 : 0.45,
-          maxHeight: focused ? undefined : "5.5rem",
-          overflow: focused ? "visible" : "hidden",
-        }}
-        className="p-2 mb-1 text-gray-800 rounded-sm border-2 text-xs bg-gray-100 transition hover:border-gray-800"
-      >
-        {children}
-      </aside>,
-      anchor
-    );
-
-  const asideVisible =
-    !!asideEl &&
-    anchor.parentElement &&
-    window.getComputedStyle(anchor.parentElement).display !== "none";
+  const focused = context?.activeId === id;
 
   return (
     <span
       ref={triggerRef}
+      data-note-anchor={id}
       style={{
         textDecorationStyle: "dotted",
         textDecorationColor: "rgba(31, 41, 55)",
-        textDecorationLine: asideVisible ? "underline" : "none",
+        textDecorationLine: "underline",
         textUnderlineOffset: "2px",
-        backgroundColor: asideHovering ? "rgb(209, 213, 219)" : undefined,
+        backgroundColor: focused ? "rgb(229, 231, 235)" : undefined,
       }}
-      className="cursor-pointer hover:bg-gray-300 transition underline break-all"
+      className="cursor-pointer break-all underline transition hover:bg-gray-300"
+      onMouseEnter={() => context?.setActiveId(id)}
+      onMouseLeave={() => context?.setActiveId(null)}
+      onFocus={() => context?.setActiveId(id)}
+      onBlur={() => context?.setActiveId(null)}
       {...props}
     >
       {label ?? "💭"}
-      {asideEl}
     </span>
   );
 }

--- a/app/components/floating-note.tsx
+++ b/app/components/floating-note.tsx
@@ -46,6 +46,13 @@ function estimateHeight(note: NoteItem, active: boolean) {
   return Math.max(44, Math.min(active ? 260 : 128, estimated || 92));
 }
 
+function hasHoverPointer() {
+  return (
+    typeof window === "undefined" ||
+    window.matchMedia("(hover: hover) and (pointer: fine)").matches
+  );
+}
+
 function placeNotes({
   notes,
   activeId,
@@ -92,7 +99,7 @@ function placeNotes({
     window.innerHeight - NOTE_RAIL_BOTTOM,
   );
 
-  const laidOut: (typeof candidates[number] & { top: number })[] = [];
+  const laidOut: ((typeof candidates)[number] & { top: number })[] = [];
   for (const item of candidates) {
     const previous = laidOut[laidOut.length - 1];
     laidOut.push({
@@ -100,7 +107,9 @@ function placeNotes({
       top: Math.max(
         NOTE_RAIL_TOP,
         item.targetTop,
-        previous ? previous.top + previous.height + NOTE_MIN_GAP : NOTE_RAIL_TOP,
+        previous
+          ? previous.top + previous.height + NOTE_MIN_GAP
+          : NOTE_RAIL_TOP,
       ),
     });
   }
@@ -126,6 +135,17 @@ function placeNotes({
   }));
 }
 
+function samePositions(a: NotePosition[], b: NotePosition[]) {
+  if (a.length !== b.length) return false;
+  return a.every(
+    (item, index) =>
+      item.id === b[index]?.id &&
+      item.top === b[index]?.top &&
+      item.targetTop === b[index]?.targetTop &&
+      item.marker === b[index]?.marker,
+  );
+}
+
 function FloatingNoteRail({
   notes,
   activeId,
@@ -140,12 +160,25 @@ function FloatingNoteRail({
   const [viewportHeight, setViewportHeight] = React.useState(0);
 
   const updatePositions = React.useCallback(() => {
+    const computePositions = () => {
+      const heights = new Map<string, number>();
+      noteRefs.current.forEach((el, id) => {
+        heights.set(id, el.offsetHeight);
+      });
+      return placeNotes({ notes, activeId, heights });
+    };
+
     setViewportHeight(window.innerHeight);
-    const heights = new Map<string, number>();
-    noteRefs.current.forEach((el, id) => {
-      heights.set(id, el.offsetHeight);
+    setPositions((current) => {
+      const next = computePositions();
+      return samePositions(current, next) ? current : next;
     });
-    setPositions(placeNotes({ notes, activeId, heights }));
+    requestAnimationFrame(() => {
+      setPositions((current) => {
+        const next = computePositions();
+        return samePositions(current, next) ? current : next;
+      });
+    });
   }, [activeId, notes]);
 
   React.useEffect(() => {
@@ -274,21 +307,18 @@ function FloatingNoteBottomSheet({
   return (
     <div className="md:hidden" aria-hidden={!isOpen}>
       <div
-        className={cx(
-          "fixed inset-0 z-30 bg-black/40 transition-opacity duration-200",
-          isOpen
-            ? "pointer-events-auto opacity-100"
-            : "pointer-events-none opacity-0",
-        )}
+        className="fixed inset-0 z-30 bg-black/40 transition-opacity duration-200"
+        style={{
+          opacity: isOpen ? 1 : 0,
+          pointerEvents: isOpen ? "auto" : "none",
+        }}
         onClick={() => setActiveId(null)}
       />
       <div
         role="dialog"
         aria-modal="true"
-        className={cx(
-          "fixed inset-x-0 bottom-0 z-40 max-h-[70vh] overflow-y-auto rounded-t-2xl bg-white px-5 pb-6 pt-3 shadow-2xl transition-transform duration-200",
-          isOpen ? "translate-y-0" : "translate-y-full",
-        )}
+        className="fixed inset-x-0 bottom-0 z-40 max-h-[70vh] overflow-y-auto rounded-t-2xl bg-white px-5 pb-6 pt-3 shadow-2xl transition-transform duration-200"
+        style={{ transform: isOpen ? "translateY(0)" : "translateY(100%)" }}
       >
         <div className="mx-auto mb-3 h-1 w-10 rounded-full bg-gray-300" />
         <button
@@ -411,15 +441,26 @@ export function FloatingNote({
         backgroundColor: focused ? "rgb(229, 231, 235)" : undefined,
       }}
       className="cursor-pointer break-all underline transition hover:bg-gray-300"
-      onMouseEnter={() => context?.setActiveId(id)}
-      onMouseLeave={() => context?.setActiveId(null)}
+      onMouseEnter={() => {
+        if (hasHoverPointer()) context?.setActiveId(id);
+      }}
+      onMouseLeave={() => {
+        if (hasHoverPointer()) context?.setActiveId(null);
+      }}
       onFocus={() => context?.setActiveId(id)}
-      onBlur={() => context?.setActiveId(null)}
+      onBlur={() => {
+        // Touch browsers often blur the inline trigger immediately after tap,
+        // which would close the mobile bottom sheet before it becomes visible.
+        if (hasHoverPointer()) {
+          context?.setActiveId(null);
+        }
+      }}
       onClick={(event) => {
         // On touch devices hover never fires, so click is the only way to
-        // surface the note. Toggle: tap again to close (mobile bottom sheet).
+        // surface the note. Always open here: focus can fire before click on
+        // mobile, and a toggle would immediately close the sheet again.
         event.preventDefault();
-        context?.setActiveId(focused ? null : id);
+        context?.setActiveId(id);
       }}
       onKeyDown={(event) => {
         if (event.key === "Enter" || event.key === " ") {

--- a/app/components/floating-note.tsx
+++ b/app/components/floating-note.tsx
@@ -238,6 +238,75 @@ function FloatingNoteRail({
   );
 }
 
+function FloatingNoteBottomSheet({
+  notes,
+  activeId,
+  setActiveId,
+}: {
+  notes: NoteItem[];
+  activeId: string | null;
+  setActiveId: (id: string | null) => void;
+}) {
+  const activeNote = notes.find((note) => note.id === activeId);
+  const isOpen = !!activeNote;
+
+  // Lock body scroll while the sheet is open so the page underneath doesn't
+  // tug on momentum scroll on iOS.
+  React.useEffect(() => {
+    if (!isOpen) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [isOpen]);
+
+  // Allow ESC to close (keyboards on tablets / accessibility).
+  React.useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setActiveId(null);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [isOpen, setActiveId]);
+
+  return (
+    <div className="md:hidden" aria-hidden={!isOpen}>
+      <div
+        className={cx(
+          "fixed inset-0 z-30 bg-black/40 transition-opacity duration-200",
+          isOpen
+            ? "pointer-events-auto opacity-100"
+            : "pointer-events-none opacity-0",
+        )}
+        onClick={() => setActiveId(null)}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        className={cx(
+          "fixed inset-x-0 bottom-0 z-40 max-h-[70vh] overflow-y-auto rounded-t-2xl bg-white px-5 pb-6 pt-3 shadow-2xl transition-transform duration-200",
+          isOpen ? "translate-y-0" : "translate-y-full",
+        )}
+      >
+        <div className="mx-auto mb-3 h-1 w-10 rounded-full bg-gray-300" />
+        <button
+          type="button"
+          aria-label="Close note"
+          className="absolute right-4 top-3 rounded-full p-1 text-gray-400 transition hover:text-gray-700"
+          onClick={() => setActiveId(null)}
+        >
+          ×
+        </button>
+        <div className="text-sm leading-relaxed text-gray-800">
+          {activeNote?.content}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function FloatingNotesProvider({
   children,
 }: {
@@ -288,6 +357,11 @@ export function FloatingNotesProvider({
         activeId={activeId}
         setActiveId={setActiveId}
       />
+      <FloatingNoteBottomSheet
+        notes={notes}
+        activeId={activeId}
+        setActiveId={setActiveId}
+      />
     </FloatingNoteContext.Provider>
   );
 }
@@ -327,6 +401,8 @@ export function FloatingNote({
     <span
       ref={triggerRef}
       data-note-anchor={id}
+      role="button"
+      tabIndex={0}
       style={{
         textDecorationStyle: "dotted",
         textDecorationColor: "rgba(31, 41, 55)",
@@ -339,6 +415,18 @@ export function FloatingNote({
       onMouseLeave={() => context?.setActiveId(null)}
       onFocus={() => context?.setActiveId(id)}
       onBlur={() => context?.setActiveId(null)}
+      onClick={(event) => {
+        // On touch devices hover never fires, so click is the only way to
+        // surface the note. Toggle: tap again to close (mobile bottom sheet).
+        event.preventDefault();
+        context?.setActiveId(focused ? null : id);
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          context?.setActiveId(focused ? null : id);
+        }
+      }}
       {...props}
     >
       {label ?? "💭"}

--- a/app/components/mdx-components.tsx
+++ b/app/components/mdx-components.tsx
@@ -149,25 +149,9 @@ export const createSectionWrapper =
   (Tag: React.FunctionComponent) =>
   ({ className, ...props }: React.AllHTMLAttributes<any>) => {
     return (
-      // Reserve right-side padding for the floating-note aside instead of
-      // using a flex sibling. With flex+stretch the body row would inherit
-      // the aside's natural height, padding short paragraphs to fit a tall
-      // note. Absolute positioning keeps section height = body content
-      // height; the note overflows visually into the reserved gutter only.
-      <section
-        className={cx(
-          "my-6 relative section-wrapper md:pr-48 lg:pr-64 xl:pr-72",
-          className
-        )}
-      >
+      <section className={cx("my-6 section-wrapper", className)}>
         {/* @ts-ignore */}
         <Tag {...props} />
-        <aside className="hidden md:block absolute top-0 right-0 md:w-48 lg:w-64 xl:w-72 pl-2 h-full pointer-events-none">
-          <div
-            className="sticky top-4 pointer-events-auto"
-            data-aside-container
-          />
-        </aside>
       </section>
     );
   };


### PR DESCRIPTION
## Context

这次是给博客文章里的 floating note 做 R0：把原来会参与段落布局、容易把短段撑高的旁注，改成真正浮在正文旁边的阅读辅助层；同时补上手机端的 bottom sheet，不让注脚在窄屏上变成不可读的 hover-only 交互。

## 协作过程

```mermaid
sequenceDiagram
    participant P as Peng
    participant A as 奥特曼
    participant H as 没有人类了
    participant UI as next-blog-neo

    P->>A: floating note 可能需要 creative 实现
    A->>UI: 抽出 page-level fixed rail，避免 section-local aside 撑高正文
    A->>H: 暴露 FloatingNotesProvider/active note 语义
    H->>UI: 补 mobile bottom sheet，复用同一份 note state
    A->>UI: QA 发现 touch/focus/blur 打架与 note overlap
    A->>UI: 修移动端开关、inline open state、desktop 二次测量排布
    A->>P: Playwright + build 验证后交付 R0
```

Note：关键转折点有两个。第一，desktop rail 必须脱离正文段落流，否则短段会被旁注高度影响。第二，mobile 不能复用 hover 语义；tap anchor 时浏览器会合成 mouse/focus/blur 事件，原来的 toggle 很容易刚打开又关闭。

## 方案讨论

R0 没有继续在每个 section 内放 `aside`，而是把所有 note 注册到 `FloatingNotesProvider`，由 page-level rail 根据 anchor 的 viewport 坐标统一排布。这样旁注不再参与正文高度计算，也能集中处理多个注脚靠得太近时的碰撞。

移动端采用单一 bottom sheet，而不是把多个 note 堆叠或做复杂横向切换。原因是手机上一次只需要解释当前点到的注脚；多 note 同屏展示会制造额外噪音，也更难保证滚动和关闭手势稳定。

QA 里还修了两个实现细节：

- touch 设备上只让 click 打开 sheet，关闭交给 ESC、scrim 和 close button，避免 hover/focus/blur 合成事件互相打架。
- sheet/scrim 的 open state 用 inline `style` 控制，避免 Tailwind `translate-y-0` / `translate-y-full`、`opacity-0` / `opacity-100` 的生成顺序导致最终样式不符合 React state。

## 最终方案

```mermaid
flowchart LR
    MDX[MDX link / Note] --> Anchor[FloatingNote anchor]
    Anchor --> Provider[FloatingNotesProvider]
    Provider --> Rail[Desktop fixed rail]
    Provider --> Sheet[Mobile bottom sheet]
    Rail --> Layout[viewport-aware collision layout]
    Sheet --> Controls[scrim / ESC / close button]
```

- `FloatingNote` 注册 anchor + note content，桌面 hover/focus 激活，移动端 tap 激活。
- `FloatingNotesProvider` 统一保存 notes、activeId 和 anchor refs。
- `FloatingNoteRail` 固定在页面右侧，根据当前 viewport 中的 anchor 计算 note 位置；渲染后再二次测量，避免真实内容高度变化后 overlap。
- `FloatingNoteBottomSheet` 在 `< md` 断点显示 active note，带 scrim、scroll lock、ESC 和 close button。
- MDX link lookup 支持 Notion note id，把 footnote-like 内容转为 floating note。

## 验证情况

- `pnpm exec tsc --noEmit --pretty false`
- `pnpm build`
- `git diff --check`
- Playwright fallback 验证 `/posts/slock-multi-agent-observations`：
  - desktop 1440px：4 个 anchors；rail 可见；max note overlap = 0；无 horizontal overflow；无 console error
  - mobile 390px：tap anchor 可打开 bottom sheet；ESC 可关闭；scrim 可关闭；body scroll lock 正常；无 horizontal overflow；无 console error

<!-- 请补充 CC 之外的验证 -->

## 已知局限 / 后续工作

- R0 mobile 没做 swipe-down 关闭或横向切换多个 note；当前只保留最稳定的单 note sheet。
- Desktop rail 仍是轻量 collision avoidance，不做复杂 leader-line / force layout。
- Build 时 Next 会尝试把 `tsconfig.json` 的 `moduleResolution` 改成 `bundler`；本次验证后已还原，未纳入本 PR。
